### PR TITLE
Unicode Content in Text Messages: Added the "type" parameter in Nexmo…

### DIFF
--- a/lib/action_texter/nexmo.rb
+++ b/lib/action_texter/nexmo.rb
@@ -83,6 +83,7 @@ class ActionTexter::NexmoClient < ActionTexter::Client
                             "from" => from,
                             "to" => to,
                             "text" => message.text,
+                            "type" => (message.text.ascii_only? ? "text" : "unicode"),
                             "client-ref" => message.reference),
         {"Content-Type" => "application/x-www-form-urlencoded"})
 


### PR DESCRIPTION
…Client, for Nexmo to handle Unicode text properly. Sets it automatically to only messages that need it, to avoid shortening the character limit for non-Unicode messages
